### PR TITLE
Updated csm-rie app version to 1.6.0

### DIFF
--- a/.github/workflows/charts_lint_test_scan.yaml
+++ b/.github/workflows/charts_lint_test_scan.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   lint-test-scan:
-    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/charts_lint_test_scan.yaml@v2
+    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/charts_lint_test_scan.yaml@v4
     with:
       lint-charts: ${{ github.event_name == 'pull_request' }}
       test-charts: false

--- a/changelog/v0.1.md
+++ b/changelog/v0.1.md
@@ -5,7 +5,19 @@ All notable changes to this project for v0.0.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2024-12-17
+
+### Changed
+
+- Fix build issues with app image (v1.6.0)
+- Added Paradise XD224 support (v1.6.0)
+- Fixes to the Intel mockup (v1.5.3)
+- Added Antero mock (v1.5.3)
+- Fixed delete subscriptions (v1.5.0)
+
 ## [0.1.0] - 2023-03-17
+
 ### Added
+
 - Initial helm chart to deploy RIE within VShasta. Currently only Mountain/Hill hardware can be discovered automatically via MEDS. Automatic discovery of River hardware is not currently supported.
 

--- a/charts/v0.1/csm-redfish-interface-emulator/Chart.yaml
+++ b/charts/v0.1/csm-redfish-interface-emulator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "csm-redfish-interface-emulator"
-version: 0.1.0
+version: 0.1.1
 description: "Kubernetes resources for csm-redfish-interface-emulator"
 home: https://github.com/Cray-HPE/csm-redfish-interface-emulator-charts
 sources:
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
 annotations:
   artifacthub.io/license: MIT
-appVersion: 1.4.0
+appVersion: 1.6.0

--- a/charts/v0.1/csm-redfish-interface-emulator/values.yaml
+++ b/charts/v0.1/csm-redfish-interface-emulator/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 1.4.0
+  appVersion: 1.6.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/csm-rie

--- a/csm-redfish-interface-emulator.compatibility.yaml
+++ b/csm-redfish-interface-emulator.compatibility.yaml
@@ -3,6 +3,7 @@
 chartVersionToCSMVersion: {}
   # Chart version: CSM version
   # ">=2.0.0": "~1.2.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
+  "0.1.0": ">=1.4.0"
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -10,7 +11,8 @@ chartVersionToCSMVersion: {}
 chartVersionToApplicationVersion: {}
   # Chart version: Application version
   # "2.0.0": "1.11.0"
-
+  "0.1.0": "1.4.0"
+  "0.1.1": "1.6.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION


### Summary and Scope

The 1.6.0 app can be rebuilt, whereas, the 1.4.0 version was could not be rebuilt.

CASMPET-7291
### Issues and Related PRs

* Resolves CASMPET-7291

### Testing

### Risks and Mitigations

