### PR TITLE
Added app 1.8.0 that supports Parry Peak and Blanca Peak

### DIFF
--- a/changelog/v0.1.md
+++ b/changelog/v0.1.md
@@ -5,6 +5,13 @@ All notable changes to this project for v0.0.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2025-12-11
+
+### Changed
+
+- Added mockup for Parry Peak (EX255a)
+- Added mockup for Blanca Peak (EX254n)
+
 ## [0.1.1] - 2024-12-17
 
 ### Changed

--- a/charts/v0.1/csm-redfish-interface-emulator/Chart.yaml
+++ b/charts/v0.1/csm-redfish-interface-emulator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "csm-redfish-interface-emulator"
-version: 0.1.1
+version: 0.1.2
 description: "Kubernetes resources for csm-redfish-interface-emulator"
 home: https://github.com/Cray-HPE/csm-redfish-interface-emulator-charts
 sources:
@@ -10,4 +10,4 @@ maintainers:
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
 annotations:
   artifacthub.io/license: MIT
-appVersion: 1.6.0
+appVersion: 1.8.0

--- a/charts/v0.1/csm-redfish-interface-emulator/values.yaml
+++ b/charts/v0.1/csm-redfish-interface-emulator/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 1.6.0
+  appVersion: 1.8.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/csm-rie

--- a/csm-redfish-interface-emulator.compatibility.yaml
+++ b/csm-redfish-interface-emulator.compatibility.yaml
@@ -13,6 +13,7 @@ chartVersionToApplicationVersion: {}
   # "2.0.0": "1.11.0"
   "0.1.0": "1.4.0"
   "0.1.1": "1.6.0"
+  "0.1.2": "1.8.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

Added Parry Peak and Blanca Peak

### Issues and Related PRs

* Resolves CASMHMS-6627

### Testing

LIST THE ENVIRONMENTS IN WHICH THESE CHANGES WERE TESTED.

Tested on:

* local docker compose
* SMD github test run

### Risks and Mitigations

none